### PR TITLE
fix(ui): add padding for SwapButton in SwapForm

### DIFF
--- a/apps/web/src/app/[lang]/(swap)/_components/SwapButton.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/SwapButton.tsx
@@ -20,7 +20,7 @@ export function SwapButton() {
 
   return (
     <button
-      className="inline-flex items-center justify-center border border-green-600 bg-green-800 text-green-300 hover:border-green-500 hover:text-green-200 focus:border-green-400 focus:text-green-200"
+      className="inline-flex cursor-pointer items-center justify-center border border-green-600 bg-green-800 p-1 text-green-300 hover:border-green-500 hover:text-green-200 focus:border-green-400 focus:text-green-200"
       onClick={handleClick}
       type="button"
     >

--- a/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
@@ -47,7 +47,7 @@ export function SwapForm() {
   const form = useAppForm(formConfig);
 
   return (
-    <div>
+    <div className="flex flex-col gap-4">
       <Box background="highlight" className="flex-row">
         <div>
           <Text.Body2


### PR DESCRIPTION
match as figma 

<img width="420" height="275" alt="Screenshot 2025-07-15 at 20 49 17" src="https://github.com/user-attachments/assets/b90e2b5f-2ad8-4fdd-9c39-b08d97ab4be3" />
