### PR TITLE
fix: network key

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./../../dist/.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add network-aware query keys to `useTokenAccounts` with environment-based network resolution; remove an unused TS reference.
> 
> - **Core (`libs/core/src/hooks/useTokenAccounts.ts`)**:
>   - Add optional `network` param and `resolveNetwork` with env-based fallbacks (defaults to `mainnet-beta`).
>   - Append resolved `networkKey` to React Query `queryKey` for both buy/sell token account queries.
>   - Small refactor: precompute `buyQueryOptions`/`sellQueryOptions`; maintain existing caching settings.
> - **Web (`apps/web/next-env.d.ts`)**:
>   - Remove reference to `dist/.next/types/routes.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df4e98accb926482fef2554e017a3ad08b8b4c57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->