### PR TITLE
fix(web): swap status fail

### DIFF
--- a/libs/core/src/constants/swapTxStatus.ts
+++ b/libs/core/src/constants/swapTxStatus.ts
@@ -1,0 +1,9 @@
+export enum SwapTxStatus {
+  UNSIGNED,
+  SIGNED,
+  CONFIRMED,
+  SETTLED,
+  SLASHED,
+  CANCELLED,
+  FAILED,
+}

--- a/libs/core/src/hooks/useTransactionStatus.ts
+++ b/libs/core/src/hooks/useTransactionStatus.ts
@@ -17,9 +17,13 @@ export interface UseTransactionStatusConfig<T = unknown> {
   failStates: string[];
   maxAttempts?: number;
   retryDelay?: number;
-  onStatusUpdate?: (status: string, attempt: number) => void;
-  onSuccess?: (result: StatusCheckResult<T>) => void;
-  onFailure?: (result: StatusCheckResult<T>) => void;
+  onStatusUpdate?: (
+    status: string,
+    attempt: number,
+    trackingId?: string,
+  ) => void;
+  onSuccess?: (result: StatusCheckResult<T>, trackingId?: string) => void;
+  onFailure?: (result: StatusCheckResult<T>, trackingId?: string) => void;
   onTimeout?: () => void;
 }
 
@@ -47,15 +51,15 @@ export const useTransactionStatus = <T = unknown>({
         try {
           const result = await checkStatus(trackingId, tradeId);
 
-          onStatusUpdate?.(result.status, attempt + 1);
+          onStatusUpdate?.(result.status, attempt + 1, trackingId);
 
           if (successStates.includes(result.status)) {
-            onSuccess?.(result);
+            onSuccess?.(result, trackingId);
             return;
           }
 
           if (failStates.includes(result.status)) {
-            onFailure?.(result);
+            onFailure?.(result, trackingId);
             return;
           }
 
@@ -70,8 +74,8 @@ export const useTransactionStatus = <T = unknown>({
 
           if (attempt === maxAttempts - 1) {
             onFailure?.({
-              status: "error",
               error: error instanceof Error ? error.message : "Unknown error",
+              status: "error",
             });
             return;
           }

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,17 +1,71 @@
+export { SwapTxStatus } from "./constants/swapTxStatus";
+export {
+  BUTTON_MESSAGES,
+  ERROR_MESSAGES,
+  SUCCESS_MESSAGES,
+  TRANSACTION_DESCRIPTIONS,
+  TRANSACTION_STEPS,
+  type TransactionStep,
+  type TransactionType,
+} from "./constants/toastMessages";
+export {
+  type TokenAccount,
+  type TokenAccountsData,
+  type TokenAccountsQueryClient,
+  type UseTokenAccountsParams,
+  type UseTokenAccountsReturn,
+  useTokenAccounts,
+} from "./hooks/useTokenAccounts";
+export {
+  type UseTransactionSigningParams,
+  type UseTransactionSigningReturn,
+  useTransactionSigning,
+} from "./hooks/useTransactionSigning";
+export {
+  type TransactionState,
+  type UseTransactionStateReturn,
+  useTransactionState,
+} from "./hooks/useTransactionState";
+export {
+  type StatusCheckResult,
+  type UseTransactionStatusConfig,
+  type UseTransactionStatusReturn,
+  useTransactionStatus,
+} from "./hooks/useTransactionStatus";
+export {
+  type DismissToastFunction,
+  type ToastFunction,
+  type UseTransactionToastsParams,
+  type UseTransactionToastsReturn,
+  useTransactionToasts,
+} from "./hooks/useTransactionToasts";
+export {
+  type UseLiquidityTrackingParams,
+  type UseLiquidityTrackingReturn,
+  type UseSwapTrackingParams,
+  type UseSwapTrackingReturn,
+  useLiquidityTracking,
+  useSwapTracking,
+} from "./hooks/useTransactionTracking";
 export type { Pool } from "./model/pool";
 export type { SwapTransaction } from "./model/swap";
 export type { Token } from "./model/token";
 export { SolanaAddressSchema } from "./schema/solanaAddress.schema";
 export {
-  validateWalletForSigning,
-  isWalletConnected,
-  hasSigningCapability,
-  type WalletSigningCapabilities,
-} from "./utils/walletValidation";
+  createLiquidityTracker,
+  createSwapTracker,
+  type ErrorTrackingParams,
+  type LiquidityTrackingParams,
+  type SwapTrackingParams,
+  standardizeErrorTracking,
+  type TransactionStatus,
+  type TransactionTracker,
+} from "./utils/analyticsHelpers";
+export { EXCHANGE_PROGRAM_ID, getLpTokenMint } from "./utils/getLpTokenMint";
 export {
   validateIdl,
-  validateIdlInstructions,
   validateIdlComprehensive,
+  validateIdlInstructions,
 } from "./utils/idlValidation";
 export {
   createDarklakeProgram,
@@ -19,68 +73,15 @@ export {
   createSwapProgram,
   validateProgramMethods,
 } from "./utils/programFactory";
-export { getLpTokenMint, EXCHANGE_PROGRAM_ID } from "./utils/getLpTokenMint";
 export {
   createMemoTransaction,
   signMessageCompat,
-  verifyMemoSignature,
   type VerifyMemoSignatureParams,
+  verifyMemoSignature,
 } from "./utils/signMessageWithMemo";
 export {
-  TRANSACTION_STEPS,
-  TRANSACTION_DESCRIPTIONS,
-  ERROR_MESSAGES,
-  SUCCESS_MESSAGES,
-  BUTTON_MESSAGES,
-  type TransactionType,
-  type TransactionStep,
-} from "./constants/toastMessages";
-export {
-  useTransactionState,
-  type TransactionState,
-  type UseTransactionStateReturn,
-} from "./hooks/useTransactionState";
-export {
-  useTransactionSigning,
-  type UseTransactionSigningParams,
-  type UseTransactionSigningReturn,
-} from "./hooks/useTransactionSigning";
-export {
-  useTransactionStatus,
-  type UseTransactionStatusConfig,
-  type UseTransactionStatusReturn,
-  type StatusCheckResult,
-} from "./hooks/useTransactionStatus";
-export {
-  useTransactionToasts,
-  type UseTransactionToastsParams,
-  type UseTransactionToastsReturn,
-  type ToastFunction,
-  type DismissToastFunction,
-} from "./hooks/useTransactionToasts";
-export {
-  useSwapTracking,
-  useLiquidityTracking,
-  type UseSwapTrackingParams,
-  type UseSwapTrackingReturn,
-  type UseLiquidityTrackingParams,
-  type UseLiquidityTrackingReturn,
-} from "./hooks/useTransactionTracking";
-export {
-  useTokenAccounts,
-  type UseTokenAccountsParams,
-  type UseTokenAccountsReturn,
-  type TokenAccountsQueryClient,
-  type TokenAccountsData,
-  type TokenAccount,
-} from "./hooks/useTokenAccounts";
-export {
-  createSwapTracker,
-  createLiquidityTracker,
-  standardizeErrorTracking,
-  type SwapTrackingParams,
-  type LiquidityTrackingParams,
-  type ErrorTrackingParams,
-  type TransactionStatus,
-  type TransactionTracker,
-} from "./utils/analyticsHelpers";
+  hasSigningCapability,
+  isWalletConnected,
+  validateWalletForSigning,
+  type WalletSigningCapabilities,
+} from "./utils/walletValidation";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds SwapTxStatus enum, updates useTransactionStatus to include trackingId in callbacks, and refactors SwapForm to use enum-based states with improved toast/status handling.
> 
> - **Core**:
>   - **SwapTxStatus**: Add enum `SwapTxStatus` and export it via `@dex-web/core`.
>   - **useTransactionStatus**: Extend callbacks to include optional `trackingId`; propagate it on updates/success/failure and adjust error object construction; update exports in `index.ts`.
> - **Web (SwapForm)**:
>   - Use `SwapTxStatus` for `successStates`/`failStates` via `toString()` mapping.
>   - Update `onFailure`, `onStatusUpdate`, and `onSuccess` to accept/use `trackingId`; map cancelled/failed labels; dismiss toasts before showing new ones.
>   - Minor UX: show status toast with current tracking id; dismiss before success toast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b604cc45926b10641dd60334046d71b9eaeccdfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->