### PR TITLE
feat: use allowlist at runtime

### DIFF
--- a/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
@@ -4,7 +4,6 @@ import { SelectTokenModal } from "../../../../../_components/SelectTokenModal";
 import { getTokensAllowList } from "../../../../../_utils/getTokensAllowList";
 import { selectedTokensCache } from "../../../../../_utils/searchParams";
 
-const allowList = getTokensAllowList();
 export default async function Page({
   searchParams,
   params,
@@ -13,6 +12,8 @@ export default async function Page({
   params: Promise<{ type: "buy" | "sell" }>;
 }) {
   await selectedTokensCache.parse(searchParams);
+
+  const allowList = getTokensAllowList();
 
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
@@ -4,7 +4,6 @@ import { SelectTokenModal } from "../../../../_components/SelectTokenModal";
 import { getTokensAllowList } from "../../../../_utils/getTokensAllowList";
 import { selectedTokensCache } from "../../../../_utils/searchParams";
 
-const allowList = getTokensAllowList();
 export default async function Page({
   searchParams,
   params,
@@ -13,6 +12,8 @@ export default async function Page({
   params: Promise<{ type: "buy" | "sell" }>;
 }) {
   await selectedTokensCache.parse(searchParams);
+
+  const allowList = getTokensAllowList();
 
   return (
     <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Initialize the token allowlist inside `Page` for both select-token routes instead of at module scope.
> 
> - **Frontend**
>   - **Select token pages** (`apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx`, `apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx`):
>     - Move `getTokensAllowList()` call from module scope into `Page` to compute `allowList` at runtime.
>     - Pass the computed `allowList` to `SelectTokenModal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2012b21853fb5cba6428c3b1c7549106420c146a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->