### PR TITLE
Release 03/10/25 2

### DIFF
--- a/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
@@ -4,7 +4,6 @@ import { SelectTokenModal } from "../../../../../_components/SelectTokenModal";
 import { getTokensAllowList } from "../../../../../_utils/getTokensAllowList";
 import { selectedTokensCache } from "../../../../../_utils/searchParams";
 
-const allowList = getTokensAllowList();
 export default async function Page({
   searchParams,
   params,
@@ -13,6 +12,8 @@ export default async function Page({
   params: Promise<{ type: "buy" | "sell" }>;
 }) {
   await selectedTokensCache.parse(searchParams);
+
+  const allowList = getTokensAllowList();
 
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
@@ -4,7 +4,6 @@ import { SelectTokenModal } from "../../../../_components/SelectTokenModal";
 import { getTokensAllowList } from "../../../../_utils/getTokensAllowList";
 import { selectedTokensCache } from "../../../../_utils/searchParams";
 
-const allowList = getTokensAllowList();
 export default async function Page({
   searchParams,
   params,
@@ -13,6 +12,8 @@ export default async function Page({
   params: Promise<{ type: "buy" | "sell" }>;
 }) {
   await selectedTokensCache.parse(searchParams);
+
+  const allowList = getTokensAllowList();
 
   return (
     <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves `getTokensAllowList()` invocation from module scope into `Page()` in both select-token pages.
> 
> - **Web | Swap → Select Token pages**:
>   - Move `getTokensAllowList()` from module scope into `Page()` after `selectedTokensCache.parse(...)` in:
>     - `apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx`
>     - `apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13ce644211156a1a432dc46a6db609850aef8a96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->