### PR TITLE
Release 03/10/25 3

### DIFF
--- a/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
@@ -1,7 +1,6 @@
 import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
 import { SelectTokenModal } from "../../../../../_components/SelectTokenModal";
-import { getTokensAllowList } from "../../../../../_utils/getTokensAllowList";
 import { selectedTokensCache } from "../../../../../_utils/searchParams";
 
 export default async function Page({
@@ -13,15 +12,9 @@ export default async function Page({
 }) {
   await selectedTokensCache.parse(searchParams);
 
-  const allowList = getTokensAllowList();
-
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <SelectTokenModal
-        allowList={allowList}
-        returnUrl={""}
-        type={(await params).type}
-      />
+      <SelectTokenModal returnUrl={""} type={(await params).type} />
     </Suspense>
   );
 }

--- a/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
@@ -1,7 +1,6 @@
 import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
 import { SelectTokenModal } from "../../../../_components/SelectTokenModal";
-import { getTokensAllowList } from "../../../../_utils/getTokensAllowList";
 import { selectedTokensCache } from "../../../../_utils/searchParams";
 
 export default async function Page({
@@ -13,15 +12,9 @@ export default async function Page({
 }) {
   await selectedTokensCache.parse(searchParams);
 
-  const allowList = getTokensAllowList();
-
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <SelectTokenModal
-        allowList={allowList}
-        returnUrl={""}
-        type={(await params).type}
-      />
+      <SelectTokenModal returnUrl={""} type={(await params).type} />
     </Suspense>
   );
 }

--- a/apps/web/src/app/_components/SelectTokenModal.tsx
+++ b/apps/web/src/app/_components/SelectTokenModal.tsx
@@ -56,13 +56,11 @@ const formConfig = {
 interface SelectTokenModalProps {
   type: "buy" | "sell";
   returnUrl: string;
-  allowList?: string[];
 }
 
 export function SelectTokenModal({
   type,
   returnUrl = "",
-  allowList,
 }: SelectTokenModalProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -148,7 +146,6 @@ export function SelectTokenModal({
   const { data } = useSuspenseQuery(
     tanstackClient.tokens.getTokens.queryOptions({
       input: {
-        allowList,
         limit: 8,
         offset: 0,
         query: debouncedQuery,

--- a/libs/core/src/utils/signMessageWithMemo.ts
+++ b/libs/core/src/utils/signMessageWithMemo.ts
@@ -39,7 +39,11 @@ export async function createMemoTransaction(
 export async function signMessageCompat(
   wallet: Wallet,
   message: string,
-  connection: Connection = new Connection(clusterApiUrl("devnet")),
+  connection: Connection = new Connection(
+    clusterApiUrl(
+      process.env.NEXT_PUBLIC_NETWORK === "2" ? "devnet" : "mainnet-beta",
+    ),
+  ),
 ): Promise<{ signature: string; transaction?: Transaction }> {
   const walletAdapter = wallet.adapter;
   if (!walletAdapter.publicKey) {

--- a/libs/orpc/src/handlers/tokens/getTokens.handler.ts
+++ b/libs/orpc/src/handlers/tokens/getTokens.handler.ts
@@ -1,15 +1,32 @@
 "use server";
 
 import type { GetTokenMetadataListRequest } from "@dex-web/grpc-client";
+import type { ClientContext } from "../../client";
 import { tokensData, tokensDataMainnet } from "../../mocks/tokens.mock";
 import type {
   GetTokensInput,
   GetTokensOutput,
 } from "../../schemas/tokens/getTokens.schema";
+import { getTokensAllowList } from "../../utils/getTokensAllowList";
 import { getTokenMetadataListHandler } from "../dex-gateway/getTokenMetadataList.handler";
+
+const isSwapContext = (context?: ClientContext): boolean => {
+  if (!context || typeof context !== "object") return false;
+
+  const headers = (context as any).headers;
+  if (!headers || typeof headers !== "object") return false;
+
+  const referer = headers.referer || headers.referrer;
+  if (!referer || typeof referer !== "string") return false;
+
+  const swapPaths = ["/select-token/", "/(swap)/", "/swap/"];
+
+  return swapPaths.some((path) => referer.includes(path));
+};
 
 export const getTokensHandler = async (
   input: GetTokensInput,
+  context?: ClientContext,
 ): Promise<GetTokensOutput> => {
   const { limit = 10, query, offset = 0, allowList } = input;
   const page = Math.floor(offset / limit) + 1;
@@ -44,24 +61,39 @@ export const getTokensHandler = async (
 
   const fullTokensList = [...localTokensList, ...gatewayTokensList];
   if (!query) {
+    const effectiveAllowList = isSwapContext(context)
+      ? getTokensAllowList()
+      : allowList;
+    const filteredTokens = effectiveAllowList
+      ? localTokensList.filter((token) =>
+          effectiveAllowList.includes(token.address),
+        )
+      : localTokensList;
+
     return {
-      hasMore: localTokensList.length > limit,
-      tokens: localTokensList.map((token) => ({
+      hasMore: filteredTokens.length > limit,
+      tokens: filteredTokens.slice(0, limit).map((token) => ({
         address: token.address,
         decimals: token.decimals,
         imageUrl: token.logoUri,
         name: token.name,
         symbol: token.symbol,
       })),
-      total: localTokensList.length,
+      total: filteredTokens.length,
     };
   }
 
   const total = fullTokensList.length;
   const hasMore = fullTokensList.length > limit;
 
+  const effectiveAllowList = isSwapContext(context)
+    ? getTokensAllowList()
+    : allowList;
+
   const filteredTokensList = fullTokensList
-    .filter((token) => (allowList ? allowList.includes(token.address) : true))
+    .filter((token) =>
+      effectiveAllowList ? effectiveAllowList.includes(token.address) : true,
+    )
     .filter(
       (token) =>
         token.address.toUpperCase().includes(query.toUpperCase()) ||

--- a/libs/orpc/src/procedures/tokens/getTokens.procedure.ts
+++ b/libs/orpc/src/procedures/tokens/getTokens.procedure.ts
@@ -4,6 +4,6 @@ import { baseProcedure } from "../base.procedure";
 
 export const getTokens = baseProcedure
   .input(getTokensInputSchema)
-  .handler(async ({ input }) => {
-    return await getTokensHandler(input);
+  .handler(async ({ input, context }) => {
+    return await getTokensHandler(input, context);
   });

--- a/libs/orpc/src/utils/getTokensAllowList.ts
+++ b/libs/orpc/src/utils/getTokensAllowList.ts
@@ -1,4 +1,4 @@
-import { tokensData, tokensDataMainnet } from "@dex-web/orpc/mocks/tokens.mock";
+import { tokensData, tokensDataMainnet } from "../mocks/tokens.mock";
 
 export const getTokensAllowList = () => {
   const list = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shift token allowlist filtering to the server based on request context, adjust pagination, remove client allowlist usage, and choose Solana cluster by env for signing.
> 
> - **Tokens API (server)**:
>   - Context-aware allowlist: derive `allowList` via `getTokensAllowList()` when request referer indicates swap routes; otherwise use provided `allowList`.
>   - Adjust no-query response: filter by effective allowlist, slice to `limit`, and compute `hasMore`/`total` accordingly.
>   - Apply allowlist filtering to queried results as well.
>   - Procedure now forwards `context` to handler.
> - **Web (Select Token)**:
>   - Remove `allowList` prop and related imports; `SelectTokenModal` no longer passes `allowList` to `getTokens`.
> - **Core**:
>   - `signMessageCompat` default connection selects `devnet` or `mainnet-beta` based on `NEXT_PUBLIC_NETWORK`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cff898310877da5cc427359a30e5e0ce6900d387. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->