### PR TITLE
fix: swap success toast message

### DIFF
--- a/apps/web/src/app/[lang]/(swap)/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/page.tsx
@@ -1,8 +1,10 @@
 import { tanstackClient } from "@dex-web/orpc";
 import { Box, Hero, Text } from "@dex-web/ui";
 import { sortSolanaAddresses } from "@dex-web/utils";
+import { SkeletonForm } from "apps/web/src/app/_components/SkeletonForm";
 import { SwapTransactionHistory } from "apps/web/src/app/[lang]/(swap)/_components/SwapTransactionHistory";
 import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import { getQueryClient, HydrateClient } from "../../../lib/query/hydration";
 import { queryKeys } from "../../../lib/queryKeys";
 import { FeaturesAndTrendingPoolPanel } from "../../_components/FeaturesAndTrendingPoolPanel";
@@ -116,7 +118,10 @@ export default async function Page({
             </Box>
             <div className="size-9" />
           </section>
-          <SwapForm />
+          <Suspense fallback={<SkeletonForm />}>
+            <SwapForm />
+          </Suspense>
+
           <SwapTransactionHistory />
         </div>
         <div className="hidden max-w-xs md:block">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Formats the swap success toast with token symbols and nicely formatted amounts, and wraps `SwapForm` in `Suspense` with a `SkeletonForm` fallback.
> 
> - **Swap success toast**:
>   - Uses `useSuspenseQuery` to fetch token metadata via `tanstackClient.tokens.getTokenMetadata` and display token symbols instead of addresses in the success message in `apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx`.
>   - Formats amounts with `numberFormatHelper` (5 decimal places, trimmed zeros) in the success toast.
> - **UI/Loading state**:
>   - Wraps `SwapForm` in `Suspense` with `SkeletonForm` fallback in `apps/web/src/app/[lang]/(swap)/page.tsx` for improved loading UX.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9395b4407e00b8d75909bc4909de553c78a8a09a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->