### PR TITLE
Bug/dar 813 cant trade sol

### DIFF
--- a/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
@@ -21,6 +21,7 @@ import {
   formatAmountInput,
   parseAmount,
   parseAmountBigNumber,
+  replaceSolWithWsol,
   sortSolanaAddresses,
   toRawUnitsBigint,
 } from "@dex-web/utils";
@@ -238,6 +239,8 @@ export function SwapForm() {
       });
 
       if (tokenAAddress && tokenBAddress) {
+        // const replacedTokens = replaceSolWithWsol(tokenAAddress, tokenBAddress);
+
         const sortedTokens = sortSolanaAddresses(tokenAAddress, tokenBAddress);
         const { tokenXAddress: tokenXMint, tokenYAddress: tokenYMint } =
           sortedTokens;
@@ -278,11 +281,17 @@ export function SwapForm() {
     ),
   });
 
+  // Apply replaceSolWithWsol to get the correct token addresses for pool details
+  const processedTokens =
+    tokenAAddress && tokenBAddress
+      ? replaceSolWithWsol(tokenAAddress, tokenBAddress)
+      : { tokenAAddress, tokenBAddress };
+
   const { data: poolDetails } = useSuspenseQuery(
     tanstackClient.pools.getPoolDetails.queryOptions({
       input: {
-        tokenXMint: tokenBAddress,
-        tokenYMint: tokenAAddress,
+        tokenXMint: processedTokens.tokenBAddress,
+        tokenYMint: processedTokens.tokenAAddress,
       },
     }),
   );

--- a/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
@@ -239,8 +239,6 @@ export function SwapForm() {
       });
 
       if (tokenAAddress && tokenBAddress) {
-        // const replacedTokens = replaceSolWithWsol(tokenAAddress, tokenBAddress);
-
         const sortedTokens = sortSolanaAddresses(tokenAAddress, tokenBAddress);
         const { tokenXAddress: tokenXMint, tokenYAddress: tokenYMint } =
           sortedTokens;
@@ -282,7 +280,7 @@ export function SwapForm() {
   });
 
   // Apply replaceSolWithWsol to get the correct token addresses for pool details
-  const processedTokens =
+  const solReplacedTokens =
     tokenAAddress && tokenBAddress
       ? replaceSolWithWsol(tokenAAddress, tokenBAddress)
       : { tokenAAddress, tokenBAddress };
@@ -290,8 +288,8 @@ export function SwapForm() {
   const { data: poolDetails } = useSuspenseQuery(
     tanstackClient.pools.getPoolDetails.queryOptions({
       input: {
-        tokenXMint: processedTokens.tokenBAddress,
-        tokenYMint: processedTokens.tokenAAddress,
+        tokenXMint: solReplacedTokens.tokenBAddress,
+        tokenYMint: solReplacedTokens.tokenAAddress,
       },
     }),
   );

--- a/libs/orpc/src/handlers/pools/getPoolDetails.handler.ts
+++ b/libs/orpc/src/handlers/pools/getPoolDetails.handler.ts
@@ -20,10 +20,10 @@ function getPoolOnLocalData(tokenXMint: string, tokenYMint: string) {
 async function savePoolToLocalData(pool: PoolAccount) {
   return {
     apr: 0,
-    tokenXMint: pool.reserve_x.toBase58(),
-    tokenXSymbol: pool.reserve_x.toBase58(),
-    tokenYMint: pool.reserve_y.toBase58(),
-    tokenYSymbol: pool.reserve_y.toBase58(),
+    tokenXMint: pool.token_mint_x.toBase58(),
+    tokenXSymbol: pool.token_mint_x.toBase58(),
+    tokenYMint: pool.token_mint_y.toBase58(),
+    tokenYSymbol: pool.token_mint_y.toBase58(),
   };
 }
 

--- a/libs/orpc/src/mocks/pool.mock.ts
+++ b/libs/orpc/src/mocks/pool.mock.ts
@@ -6,6 +6,13 @@ export const MOCK_POOLS = [
     tokenYMint: "HXsKnhXPtGr2mq4uTpxbxyy7ZydYWJwx4zMuYPEDukY",
     tokenYSymbol: "DukY",
   },
+  {
+    apr: 0,
+    tokenXMint: "So11111111111111111111111111111111111111111",
+    tokenXSymbol: "SOL",
+    tokenYMint: "DdLxrGFs2sKYbbqVk76eVx9268ASUdTMAhrsqphqDuX",
+    tokenYSymbol: "DuX",
+  },
 ];
 
 export const MAINNET_POOLS = [

--- a/libs/orpc/src/mocks/tokenPrices.mock.ts
+++ b/libs/orpc/src/mocks/tokenPrices.mock.ts
@@ -1,7 +1,10 @@
+import { SOL_MINT, WSOL_MINT } from "../utils/solana";
+
 export const mockPrices: Record<string, number> = {
   "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs": 85.75,
   DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263: 0.95,
   EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: 1.0,
   mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So: 145.8,
-  So11111111111111111111111111111111111111112: 150.25,
+  [SOL_MINT]: 150.25,
+  [WSOL_MINT]: 150.25,
 };

--- a/libs/orpc/src/mocks/tokens.mock.ts
+++ b/libs/orpc/src/mocks/tokens.mock.ts
@@ -16,6 +16,13 @@ export const tokensData = [
     name: "DukY",
     symbol: "DukY",
   }),
+  create(TokenMetadataPB, {
+    address: "So11111111111111111111111111111111111111111",
+    decimals: 9,
+    logoUri: "",
+    name: "SOL",
+    symbol: "SOL",
+  }),
 ];
 
 export const tokensDataMainnet = [

--- a/libs/orpc/src/utils/solana.ts
+++ b/libs/orpc/src/utils/solana.ts
@@ -26,11 +26,17 @@ export const MAX_PERCENTAGE = 1000000;
 
 export const LP_TOKEN_DECIMALS = 9;
 
+// SOL native token address
+export const SOL_MINT = "So11111111111111111111111111111111111111111";
+export const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
 export const IDL_CODER = new BorshCoder(IDL as Idl);
 
 export type PoolAccount = {
-  reserve_x: PublicKey;
-  reserve_y: PublicKey;
+  token_mint_x: PublicKey;
+  token_mint_y: PublicKey;
+  reserve_x: PublicKey; // pool token account
+  reserve_y: PublicKey; // pool token account
   locked_x: number;
   locked_y: number;
   user_locked_x: number;

--- a/libs/utils/src/blockchain/replaceSolWithWsol.ts
+++ b/libs/utils/src/blockchain/replaceSolWithWsol.ts
@@ -1,0 +1,15 @@
+export const SOL_MINT = "So11111111111111111111111111111111111111111";
+export const WSOL_MINT = "So11111111111111111111111111111111111111112";
+
+export function replaceSolWithWsol(
+  addrA: string,
+  addrB: string,
+): { tokenAAddress: string; tokenBAddress: string } {
+  if (addrA === SOL_MINT) {
+    return { tokenAAddress: WSOL_MINT, tokenBAddress: addrB };
+  }
+  if (addrB === SOL_MINT) {
+    return { tokenAAddress: addrA, tokenBAddress: WSOL_MINT };
+  }
+  return { tokenAAddress: addrA, tokenBAddress: addrB };
+}

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -10,6 +10,7 @@ export { getExplorerUrl } from "./blockchain/explorerUrl";
 export { groupTransactionByDate } from "./blockchain/groupTransactionByDate";
 export { isSolanaAddress } from "./blockchain/isSolanaAddress";
 export { isValidSolanaAddress } from "./blockchain/isValidSolanaAddress";
+export { replaceSolWithWsol } from "./blockchain/replaceSolWithWsol";
 export { sortSolanaAddresses } from "./blockchain/sortSolanaAddresses";
 export { pasteFromClipboard } from "./browser/pasteFromClipboard";
 export {


### PR DESCRIPTION
**Work in progress**

- replace SOL with WSOL before passing to pool details / quote so the functions underneath use WSOL/x pool instead of SOL/x (which don't exist)
- user balance returns accurate SOL balance for SOL
- fix incorrect pool property mapping when loading on-chain data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable SOL swaps by mapping SOL→WSOL for pool/quote flows, return native SOL balances, and fix pool details to use token mint fields; update mocks and prices.
> 
> - **Swap/Frontend**:
>   - Use `replaceSolWithWsol` in `apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx` to map `SOL` to `WSOL` before fetching `pools.getPoolDetails` (uses `tokenXMint`/`tokenYMint`).
> - **ORPC/Handlers**:
>   - `libs/orpc/src/handlers/helius/getTokenAccounts.handler.ts`: Return native `SOL` balance via `connection.getBalance` when `mint === SOL_MINT`.
>   - `libs/orpc/src/handlers/pools/getPoolDetails.handler.ts`: Fix pool mapping to use `token_mint_x`/`token_mint_y` instead of reserves.
> - **Solana utils**:
>   - `libs/orpc/src/utils/solana.ts`: Add `SOL_MINT`/`WSOL_MINT`; update `PoolAccount` to include `token_mint_x`/`token_mint_y`.
>   - `libs/utils/src/blockchain/replaceSolWithWsol.ts`: New helper; exported via `libs/utils/src/index.ts`.
> - **Mocks**:
>   - Add `SOL` token and `SOL`↔`DuX` pool in `libs/orpc/src/mocks/*` and ensure prices for both `SOL_MINT` and `WSOL_MINT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 176e9c405f40a864130139b1a85fb844b4900f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->