### PR TITLE
refactor: remove outputDirectory from Vercel configuration

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,6 +4,5 @@
   "git": {
     "deploymentEnabled": false
   },
-  "installCommand": "cd ../../ && pnpm install",
-  "outputDirectory": "../../dist/apps/web"
+  "installCommand": "cd ../../ && pnpm install"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `outputDirectory` from `apps/web/vercel.json`, keeping `installCommand` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39177f5af5955584e545005363bde55dfa52ef28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->