### PR TITLE
fix: resolve infinite re-render loop in TokenListInfinite component

### DIFF
--- a/apps/web/src/app/[lang]/(swap)/_components/TokenListInfinite.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/TokenListInfinite.tsx
@@ -88,22 +88,13 @@ export function TokenListInfinite({
     rowVirtualizer.getVirtualItems,
   ]);
 
-  const [, setForceUpdate] = useState({});
-  const triggerRerender = useCallback(() => setForceUpdate({}), []);
-
   useLayoutEffect(() => {
     if (tokens.length > 0 && parentRef.current) {
+      setIsMeasured(false);
       rowVirtualizer.measure();
       setIsMeasured(true);
     }
   }, [tokens.length, rowVirtualizer]);
-
-  useEffect(() => {
-    if (tokens.length > 0) {
-      setIsMeasured(false);
-      triggerRerender();
-    }
-  }, [tokens.length, triggerRerender]);
 
   if (tokens.length === 0 && !isLoading) {
     return (


### PR DESCRIPTION
Fixes an infinite re-render loop that was causing hundreds of API requests to getTokenMetadataList endpoint, resulting in ERR_INSUFFICIENT_RESOURCES.

Problem:
- Two conflicting useEffect/useLayoutEffect hooks were creating a render loop
- useEffect would trigger setIsMeasured(false) + triggerRerender() on token changes
- useLayoutEffect would trigger setIsMeasured(true) on the same dependency
- This cycle repeated infinitely, overwhelming the browser with API requests

Solution:
- Consolidated both effects into a single useLayoutEffect
- Removed unnecessary triggerRerender() and force update state
- Maintains proper measurement behavior without infinite re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates measurement into a single useLayoutEffect and removes forced re-renders to stop an infinite render loop in `TokenListInfinite`.
> 
> - **Frontend**
>   - **`TokenListInfinite.tsx`**:
>     - Consolidates measurement to a single `useLayoutEffect`, setting `setIsMeasured(false)` then measuring and setting `true`.
>     - Removes forced re-render mechanism (`setForceUpdate`/`triggerRerender`) and the extra `useEffect`.
>     - Prevents infinite re-render loop and excessive fetch triggers during token list updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f677e8c8d4d88c435616c62319b9a121250761d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->