### PR TITLE
feat: add @tanstack/react-pacer

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+/// <reference path="./../../dist/apps/web/.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/@modal/(.)[lang]/(swap)/select-token/[type]/page.tsx
@@ -1,14 +1,9 @@
-import { QUERY_CONFIG, tanstackClient } from "@dex-web/orpc";
 import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
 import {
   getQueryClient,
   HydrateClient,
 } from "../../../../../../lib/query/hydration";
-import {
-  MAX_POOL_TOKENS_TO_FETCH,
-  POPULAR_TOKEN_ADDRESSES,
-} from "../../../../../_components/_hooks/constants";
 import { SelectTokenModal } from "../../../../../_components/SelectTokenModal";
 import { selectedTokensCache } from "../../../../../_utils/searchParams";
 
@@ -22,103 +17,6 @@ export default async function Page({
   await selectedTokensCache.parse(searchParams);
 
   const queryClient = getQueryClient();
-
-  const [popularTokensResult, poolsResult] = await Promise.allSettled([
-    queryClient.prefetchQuery({
-      ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-          filterBy: {
-            case: "addressesList" as const,
-            value: {
-              $typeName: "darklake.v1.TokenAddressesList" as const,
-              tokenAddresses: POPULAR_TOKEN_ADDRESSES as string[],
-            },
-          },
-          pageNumber: 1,
-          pageSize: POPULAR_TOKEN_ADDRESSES.length,
-        },
-      }),
-      gcTime: QUERY_CONFIG.tokenMetadata.gcTime,
-      staleTime: QUERY_CONFIG.tokenMetadata.staleTime,
-    }),
-
-    queryClient.prefetchQuery({
-      ...tanstackClient.pools.getAllPools.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          includeEmpty: false,
-        },
-      }),
-      gcTime: 10 * 60 * 1000,
-      staleTime: 2 * 60 * 1000,
-    }),
-  ]);
-
-  if (popularTokensResult.status === "rejected") {
-    console.warn(
-      "Failed to prefetch popular tokens:",
-      popularTokensResult.reason,
-    );
-  }
-  if (poolsResult.status === "rejected") {
-    console.warn("Failed to prefetch pools:", poolsResult.reason);
-  }
-
-  try {
-    const poolsData = queryClient.getQueryData(
-      tanstackClient.pools.getAllPools.queryKey({
-        input: {
-          includeEmpty: false,
-        },
-      }),
-    ) as
-      | { pools: Array<{ tokenXMint: string; tokenYMint: string }> }
-      | undefined;
-
-    if (poolsData?.pools && poolsData.pools.length > 0) {
-      const addressSet = new Set<string>();
-
-      POPULAR_TOKEN_ADDRESSES.forEach((addr) => addressSet.add(addr));
-
-      for (const pool of poolsData.pools) {
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenXMint);
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenYMint);
-      }
-
-      const uniqueTokenAddresses = Array.from(addressSet);
-
-      if (uniqueTokenAddresses.length > 0) {
-        await queryClient.prefetchQuery({
-          ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-            context: { cache: "force-cache" as RequestCache },
-            input: {
-              $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-              filterBy: {
-                case: "addressesList" as const,
-                value: {
-                  $typeName: "darklake.v1.TokenAddressesList" as const,
-                  tokenAddresses: uniqueTokenAddresses as string[],
-                },
-              },
-              pageNumber: 1,
-              pageSize: Math.min(
-                uniqueTokenAddresses.length,
-                MAX_POOL_TOKENS_TO_FETCH,
-              ),
-            },
-          }),
-          gcTime: QUERY_CONFIG.poolTokensMetadata.gcTime,
-          staleTime: QUERY_CONFIG.poolTokensMetadata.staleTime,
-        });
-      }
-    }
-  } catch (error) {
-    console.warn("Failed to prefetch pool token metadata:", error);
-  }
 
   return (
     <HydrateClient client={queryClient}>

--- a/apps/web/src/app/@modal/(.)[lang]/liquidity/select-token/[type]/page.tsx
+++ b/apps/web/src/app/@modal/(.)[lang]/liquidity/select-token/[type]/page.tsx
@@ -1,14 +1,9 @@
-import { QUERY_CONFIG, tanstackClient } from "@dex-web/orpc";
 import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
 import {
   getQueryClient,
   HydrateClient,
 } from "../../../../../../lib/query/hydration";
-import {
-  MAX_POOL_TOKENS_TO_FETCH,
-  POPULAR_TOKEN_ADDRESSES,
-} from "../../../../../_components/_hooks/constants";
 import { SelectTokenModal } from "../../../../../_components/SelectTokenModal";
 import { selectedTokensCache } from "../../../../../_utils/searchParams";
 
@@ -22,103 +17,6 @@ export default async function Page({
   await selectedTokensCache.parse(searchParams);
 
   const queryClient = getQueryClient();
-
-  const [popularTokensResult, poolsResult] = await Promise.allSettled([
-    queryClient.prefetchQuery({
-      ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-          filterBy: {
-            case: "addressesList" as const,
-            value: {
-              $typeName: "darklake.v1.TokenAddressesList" as const,
-              tokenAddresses: POPULAR_TOKEN_ADDRESSES as string[],
-            },
-          },
-          pageNumber: 1,
-          pageSize: POPULAR_TOKEN_ADDRESSES.length,
-        },
-      }),
-      gcTime: QUERY_CONFIG.tokenMetadata.gcTime,
-      staleTime: QUERY_CONFIG.tokenMetadata.staleTime,
-    }),
-
-    queryClient.prefetchQuery({
-      ...tanstackClient.pools.getAllPools.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          includeEmpty: false,
-        },
-      }),
-      gcTime: 10 * 60 * 1000,
-      staleTime: 2 * 60 * 1000,
-    }),
-  ]);
-
-  if (popularTokensResult.status === "rejected") {
-    console.warn(
-      "Failed to prefetch popular tokens:",
-      popularTokensResult.reason,
-    );
-  }
-  if (poolsResult.status === "rejected") {
-    console.warn("Failed to prefetch pools:", poolsResult.reason);
-  }
-
-  try {
-    const poolsData = queryClient.getQueryData(
-      tanstackClient.pools.getAllPools.queryKey({
-        input: {
-          includeEmpty: false,
-        },
-      }),
-    ) as
-      | { pools: Array<{ tokenXMint: string; tokenYMint: string }> }
-      | undefined;
-
-    if (poolsData?.pools && poolsData.pools.length > 0) {
-      const addressSet = new Set<string>();
-
-      POPULAR_TOKEN_ADDRESSES.forEach((addr) => addressSet.add(addr));
-
-      for (const pool of poolsData.pools) {
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenXMint);
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenYMint);
-      }
-
-      const uniqueTokenAddresses = Array.from(addressSet);
-
-      if (uniqueTokenAddresses.length > 0) {
-        await queryClient.prefetchQuery({
-          ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-            context: { cache: "force-cache" as RequestCache },
-            input: {
-              $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-              filterBy: {
-                case: "addressesList" as const,
-                value: {
-                  $typeName: "darklake.v1.TokenAddressesList" as const,
-                  tokenAddresses: uniqueTokenAddresses as string[],
-                },
-              },
-              pageNumber: 1,
-              pageSize: Math.min(
-                uniqueTokenAddresses.length,
-                MAX_POOL_TOKENS_TO_FETCH,
-              ),
-            },
-          }),
-          gcTime: QUERY_CONFIG.poolTokensMetadata.gcTime,
-          staleTime: QUERY_CONFIG.poolTokensMetadata.staleTime,
-        });
-      }
-    }
-  } catch (error) {
-    console.warn("Failed to prefetch pool token metadata:", error);
-  }
 
   return (
     <HydrateClient client={queryClient}>

--- a/apps/web/src/app/[lang]/(swap)/_components/TokenListInfinite.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/TokenListInfinite.tsx
@@ -88,13 +88,22 @@ export function TokenListInfinite({
     rowVirtualizer.getVirtualItems,
   ]);
 
+  const [, setForceUpdate] = useState({});
+  const triggerRerender = useCallback(() => setForceUpdate({}), []);
+
   useLayoutEffect(() => {
     if (tokens.length > 0 && parentRef.current) {
-      setIsMeasured(false);
       rowVirtualizer.measure();
       setIsMeasured(true);
     }
   }, [tokens.length, rowVirtualizer]);
+
+  useEffect(() => {
+    if (tokens.length > 0) {
+      setIsMeasured(false);
+      triggerRerender();
+    }
+  }, [tokens.length, triggerRerender]);
 
   if (tokens.length === 0 && !isLoading) {
     return (

--- a/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/select-token/[type]/page.tsx
@@ -1,4 +1,3 @@
-import { QUERY_CONFIG, tanstackClient } from "@dex-web/orpc";
 import { redirect } from "next/navigation";
 import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
@@ -6,10 +5,6 @@ import {
   getQueryClient,
   HydrateClient,
 } from "../../../../../lib/query/hydration";
-import {
-  MAX_POOL_TOKENS_TO_FETCH,
-  POPULAR_TOKEN_ADDRESSES,
-} from "../../../../_components/_hooks/constants";
 import { SelectTokenModal } from "../../../../_components/SelectTokenModal";
 import { selectedTokensCache } from "../../../../_utils/searchParams";
 
@@ -21,112 +16,15 @@ export default async function Page({
   params: Promise<{ type: "buy" | "sell" }>;
 }) {
   const resolvedSearchParams = await searchParams;
-  const from = resolvedSearchParams.from as string | undefined;
+  const from = resolvedSearchParams.from;
 
-  if (from) {
-    redirect(from as any);
+  if (from && typeof from === "string") {
+    redirect(from as never);
   }
 
   await selectedTokensCache.parse(searchParams);
 
   const queryClient = getQueryClient();
-
-  const [popularTokensResult, poolsResult] = await Promise.allSettled([
-    queryClient.prefetchQuery({
-      ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-          filterBy: {
-            case: "addressesList" as const,
-            value: {
-              $typeName: "darklake.v1.TokenAddressesList" as const,
-              tokenAddresses: POPULAR_TOKEN_ADDRESSES as string[],
-            },
-          },
-          pageNumber: 1,
-          pageSize: POPULAR_TOKEN_ADDRESSES.length,
-        },
-      }),
-      gcTime: QUERY_CONFIG.tokenMetadata.gcTime,
-      staleTime: QUERY_CONFIG.tokenMetadata.staleTime,
-    }),
-
-    queryClient.prefetchQuery({
-      ...tanstackClient.pools.getAllPools.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          includeEmpty: false,
-        },
-      }),
-      gcTime: 10 * 60 * 1000,
-      staleTime: 2 * 60 * 1000,
-    }),
-  ]);
-
-  if (popularTokensResult.status === "rejected") {
-    console.warn(
-      "Failed to prefetch popular tokens:",
-      popularTokensResult.reason,
-    );
-  }
-  if (poolsResult.status === "rejected") {
-    console.warn("Failed to prefetch pools:", poolsResult.reason);
-  }
-
-  try {
-    const poolsData = queryClient.getQueryData(
-      tanstackClient.pools.getAllPools.queryKey({
-        input: {
-          includeEmpty: false,
-        },
-      }),
-    ) as
-      | { pools: Array<{ tokenXMint: string; tokenYMint: string }> }
-      | undefined;
-
-    if (poolsData?.pools && poolsData.pools.length > 0) {
-      const addressSet = new Set<string>();
-
-      POPULAR_TOKEN_ADDRESSES.forEach((addr) => addressSet.add(addr));
-
-      for (const pool of poolsData.pools) {
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenXMint);
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenYMint);
-      }
-
-      const uniqueTokenAddresses = Array.from(addressSet);
-
-      if (uniqueTokenAddresses.length > 0) {
-        await queryClient.prefetchQuery({
-          ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-            context: { cache: "force-cache" as RequestCache },
-            input: {
-              $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-              filterBy: {
-                case: "addressesList" as const,
-                value: {
-                  $typeName: "darklake.v1.TokenAddressesList" as const,
-                  tokenAddresses: uniqueTokenAddresses as string[],
-                },
-              },
-              pageNumber: 1,
-              pageSize: Math.min(
-                uniqueTokenAddresses.length,
-                MAX_POOL_TOKENS_TO_FETCH,
-              ),
-            },
-          }),
-          gcTime: QUERY_CONFIG.poolTokensMetadata.gcTime,
-          staleTime: QUERY_CONFIG.poolTokensMetadata.staleTime,
-        });
-      }
-    }
-  } catch (error) {
-    console.warn("Failed to prefetch pool token metadata:", error);
-  }
 
   return (
     <HydrateClient client={queryClient}>

--- a/apps/web/src/app/[lang]/liquidity/_components/CreatePoolForm.tsx
+++ b/apps/web/src/app/[lang]/liquidity/_components/CreatePoolForm.tsx
@@ -26,7 +26,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { createSerializer, useQueryStates } from "nuqs";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import * as z from "zod";
 import { useAnalytics } from "../../../../hooks/useAnalytics";
 import { FormFieldset } from "../../../_components/FormFieldset";
@@ -87,15 +87,16 @@ export function CreatePoolForm({ tokenPrices = {} }: CreatePoolFormProps) {
   const isMissingTokens =
     tokenAAddress === EMPTY_TOKEN || tokenBAddress === EMPTY_TOKEN;
 
-  const sortedTokenAddresses = isMissingTokens
-    ? { tokenXAddress: tokenAAddress, tokenYAddress: tokenBAddress }
-    : (() => {
-        try {
-          return sortSolanaAddresses(tokenAAddress, tokenBAddress);
-        } catch (_error) {
-          return { tokenXAddress: tokenAAddress, tokenYAddress: tokenBAddress };
-        }
-      })();
+  const sortedTokenAddresses = useMemo(() => {
+    if (isMissingTokens) {
+      return { tokenXAddress: tokenAAddress, tokenYAddress: tokenBAddress };
+    }
+    try {
+      return sortSolanaAddresses(tokenAAddress, tokenBAddress);
+    } catch (_error) {
+      return { tokenXAddress: tokenAAddress, tokenYAddress: tokenBAddress };
+    }
+  }, [isMissingTokens, tokenAAddress, tokenBAddress]);
 
   const tokenXMint = sortedTokenAddresses.tokenXAddress;
   const tokenYMint = sortedTokenAddresses.tokenYAddress;

--- a/apps/web/src/app/[lang]/liquidity/_components/LiquidityPageContent.tsx
+++ b/apps/web/src/app/[lang]/liquidity/_components/LiquidityPageContent.tsx
@@ -30,7 +30,9 @@ export function LiquidityPageContent({
   return (
     <>
       {isCreatePoolMode ? (
-        <CreatePoolForm tokenPrices={tokenPrices} />
+        <Suspense fallback={<SkeletonForm type="liquidity" />}>
+          <CreatePoolForm tokenPrices={tokenPrices} />
+        </Suspense>
       ) : (
         <Suspense fallback={<SkeletonForm type="liquidity" />}>
           <LiquidityForm tokenPrices={tokenPrices} />

--- a/apps/web/src/app/[lang]/liquidity/_components/YourLiquidity.tsx
+++ b/apps/web/src/app/[lang]/liquidity/_components/YourLiquidity.tsx
@@ -8,7 +8,7 @@ import {
   sortSolanaAddresses,
   truncate,
 } from "@dex-web/utils";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import BigNumber from "bignumber.js";
 import { useState } from "react";
 import { useUserLiquidity } from "../../../../hooks/queries/useLiquidityQueries";
@@ -48,7 +48,7 @@ export function YourLiquidity({
 
   const shouldFetchLiquidity = !!walletPublicKey;
 
-  const { data: tokenMetadataResponse } = useSuspenseQuery({
+  const { data: tokenMetadataResponse } = useQuery({
     ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
       context: { cache: "force-cache" as RequestCache },
       input: {
@@ -64,6 +64,7 @@ export function YourLiquidity({
         pageSize: 2,
       },
     }),
+    enabled: Boolean(tokenXAddress && tokenYAddress),
     gcTime: 5 * 60 * 1000,
     queryKey: tanstackClient.dexGateway.getTokenMetadataList.queryKey({
       input: {
@@ -105,19 +106,13 @@ export function YourLiquidity({
   const tokenMetadata = tokenMetadataResponse;
 
   const tokenMetadataMap: Record<string, Token | undefined> =
-    tokenMetadata.tokens.reduce(
-      (acc, token) => {
-        acc[token.address] = {
-          address: token.address,
-          decimals: token.decimals,
-          imageUrl: token.logoUri,
-          name: token.name,
-          symbol: token.symbol,
-        };
+    tokenMetadata?.tokens?.reduce(
+      (acc: Record<string, Token>, token: Token) => {
+        acc[token.address] = token;
         return acc;
       },
       {} as Record<string, Token>,
-    );
+    ) ?? {};
 
   const tokenXDetails: Token = tokenMetadataMap[tokenXAddress] ?? {
     address: tokenXAddress,

--- a/apps/web/src/app/[lang]/liquidity/_hooks/useLPTokenEstimation.ts
+++ b/apps/web/src/app/[lang]/liquidity/_hooks/useLPTokenEstimation.ts
@@ -17,7 +17,7 @@
 
 import { tanstackClient } from "@dex-web/orpc";
 import type { TokenOrderContext } from "@dex-web/utils";
-import { useDebouncedValue } from "@dex-web/utils";
+import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
@@ -160,8 +160,12 @@ export function useLPTokenEstimation({
   slippage: _slippage,
   enabled = true,
 }: UseLPTokenEstimationParams): UseLPTokenEstimationResult {
-  const debouncedTokenAAmount = useDebouncedValue(tokenAAmount, 500);
-  const debouncedTokenBAmount = useDebouncedValue(tokenBAmount, 500);
+  const [debouncedTokenAAmount] = useDebouncedValue(tokenAAmount, {
+    wait: 500,
+  });
+  const [debouncedTokenBAmount] = useDebouncedValue(tokenBAmount, {
+    wait: 500,
+  });
 
   const { tokenXAmount, tokenYAmount, tokenXDecimals, tokenYDecimals } =
     useMemo(

--- a/apps/web/src/app/[lang]/liquidity/select-token/[type]/page.tsx
+++ b/apps/web/src/app/[lang]/liquidity/select-token/[type]/page.tsx
@@ -1,4 +1,3 @@
-import { QUERY_CONFIG, tanstackClient } from "@dex-web/orpc";
 import { redirect } from "next/navigation";
 import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
@@ -6,10 +5,6 @@ import {
   getQueryClient,
   HydrateClient,
 } from "../../../../../lib/query/hydration";
-import {
-  MAX_POOL_TOKENS_TO_FETCH,
-  POPULAR_TOKEN_ADDRESSES,
-} from "../../../../_components/_hooks/constants";
 import { SelectTokenModal } from "../../../../_components/SelectTokenModal";
 import { selectedTokensCache } from "../../../../_utils/searchParams";
 
@@ -21,110 +16,15 @@ export default async function Page({
   params: Promise<{ type: "buy" | "sell" }>;
 }) {
   const resolvedSearchParams = await searchParams;
-  const from = resolvedSearchParams.from as string | undefined;
+  const from = resolvedSearchParams.from;
 
-  if (from) {
-    redirect(from as any);
+  if (from && typeof from === "string") {
+    redirect(from as never);
   }
 
   await selectedTokensCache.parse(searchParams);
 
   const queryClient = getQueryClient();
-
-  const [popularTokensResult, poolsResult] = await Promise.allSettled([
-    queryClient.prefetchQuery({
-      ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-          filterBy: {
-            case: "addressesList" as const,
-            value: {
-              $typeName: "darklake.v1.TokenAddressesList" as const,
-              tokenAddresses: POPULAR_TOKEN_ADDRESSES as string[],
-            },
-          },
-          pageNumber: 1,
-          pageSize: POPULAR_TOKEN_ADDRESSES.length,
-        },
-      }),
-      gcTime: QUERY_CONFIG.tokenMetadata.gcTime,
-      staleTime: QUERY_CONFIG.tokenMetadata.staleTime,
-    }),
-
-    queryClient.prefetchQuery({
-      ...tanstackClient.pools.getAllPools.queryOptions({
-        context: { cache: "force-cache" as RequestCache },
-        input: {
-          includeEmpty: false,
-        },
-      }),
-      gcTime: 10 * 60 * 1000,
-      staleTime: 2 * 60 * 1000,
-    }),
-  ]);
-
-  if (popularTokensResult.status === "rejected") {
-    console.warn(
-      "Failed to prefetch popular tokens:",
-      popularTokensResult.reason,
-    );
-  }
-  if (poolsResult.status === "rejected") {
-    console.warn("Failed to prefetch pools:", poolsResult.reason);
-  }
-
-  try {
-    const poolsData = queryClient.getQueryData(
-      tanstackClient.pools.getAllPools.queryKey({
-        input: {
-          includeEmpty: false,
-        },
-      }),
-    ) as
-      | { pools: Array<{ tokenXMint: string; tokenYMint: string }> }
-      | undefined;
-
-    if (poolsData?.pools && poolsData.pools.length > 0) {
-      const addressSet = new Set<string>(POPULAR_TOKEN_ADDRESSES);
-
-      for (const pool of poolsData.pools) {
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenXMint);
-        if (addressSet.size >= MAX_POOL_TOKENS_TO_FETCH) break;
-        addressSet.add(pool.tokenYMint);
-      }
-
-      const uniqueTokenAddresses = Array.from(addressSet);
-
-      if (uniqueTokenAddresses.length > 0) {
-        await queryClient.prefetchQuery({
-          ...tanstackClient.dexGateway.getTokenMetadataList.queryOptions({
-            context: { cache: "force-cache" as RequestCache },
-            input: {
-              $typeName: "darklake.v1.GetTokenMetadataListRequest" as const,
-              filterBy: {
-                case: "addressesList" as const,
-                value: {
-                  $typeName: "darklake.v1.TokenAddressesList" as const,
-                  tokenAddresses: uniqueTokenAddresses as string[],
-                },
-              },
-              pageNumber: 1,
-              pageSize: Math.min(
-                uniqueTokenAddresses.length,
-                MAX_POOL_TOKENS_TO_FETCH,
-              ),
-            },
-          }),
-          gcTime: QUERY_CONFIG.poolTokensMetadata.gcTime,
-          staleTime: QUERY_CONFIG.poolTokensMetadata.staleTime,
-        });
-      }
-    }
-  } catch (error) {
-    console.warn("Failed to prefetch pool token metadata:", error);
-  }
 
   return (
     <HydrateClient client={queryClient}>

--- a/apps/web/src/app/_components/FeaturesAndTrendingPoolPanel.tsx
+++ b/apps/web/src/app/_components/FeaturesAndTrendingPoolPanel.tsx
@@ -1,25 +1,14 @@
 "use client";
 
 import type { Pool } from "@dex-web/core";
-import { tanstackClient } from "@dex-web/orpc";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { useQueryStates } from "nuqs";
+import { usePinnedPools } from "../../hooks/queries/usePoolQueries";
 import { LIQUIDITY_PAGE_TYPE } from "../_utils/constants";
 import { liquidityPageParsers } from "../_utils/searchParams";
 import { ShortPoolPanel } from "../[lang]/(swap)/_components/ShortPoolPanel";
 
 export function FeaturesAndTrendingPoolPanel() {
-  const { data } = useSuspenseQuery({
-    ...tanstackClient.pools.getPinedPool.queryOptions({
-      context: { cache: "force-cache" as RequestCache },
-    }),
-    gcTime: 5 * 60 * 1000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    retry: 2,
-    retryDelay: 1000,
-    staleTime: 60 * 1000,
-  });
+  const { data } = usePinnedPools();
   const [_, setSelectedTokens] = useQueryStates(liquidityPageParsers);
 
   const onPoolClick = (pool: Pool) => {
@@ -30,9 +19,13 @@ export function FeaturesAndTrendingPoolPanel() {
     });
   };
 
+  if (!data?.featuredPools && !data?.trendingPools) {
+    return null;
+  }
+
   return (
     <div className="flex w-full min-w-xs flex-col items-center gap-10 bg-transparent">
-      {data.featuredPools.length > 0 && (
+      {data?.featuredPools?.length > 0 && (
         <ShortPoolPanel
           icon="crown"
           onPoolClick={onPoolClick}
@@ -40,7 +33,7 @@ export function FeaturesAndTrendingPoolPanel() {
           title="Featured Pools"
         />
       )}
-      {data.trendingPools.length > 0 && (
+      {data?.trendingPools?.length > 0 && (
         <ShortPoolPanel
           icon="fire"
           onPoolClick={onPoolClick}
@@ -48,7 +41,6 @@ export function FeaturesAndTrendingPoolPanel() {
           title="Trending Pools"
         />
       )}
-      {}
     </div>
   );
 }

--- a/apps/web/src/app/_components/SelectTokenModal.tsx
+++ b/apps/web/src/app/_components/SelectTokenModal.tsx
@@ -2,13 +2,14 @@
 
 import type { Token } from "@dex-web/orpc/schemas/index";
 import { Box, Button, Modal, TextInput } from "@dex-web/ui";
-import { pasteFromClipboard, useDebouncedValue } from "@dex-web/utils";
+import { pasteFromClipboard } from "@dex-web/utils";
 import {
   type AnyFieldApi,
   createFormHook,
   createFormHookContexts,
   useStore,
 } from "@tanstack/react-form";
+import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createSerializer, useQueryStates } from "nuqs";
 import { Suspense, useCallback, useState } from "react";
@@ -131,7 +132,9 @@ export function SelectTokenModal({
   const rawQuery = useStore(form.store, (state) => state.values.query);
   const isInitialLoad = rawQuery === "";
 
-  const debouncedQuery = useDebouncedValue(rawQuery, isInitialLoad ? 0 : 300);
+  const [debouncedQuery] = useDebouncedValue(rawQuery, {
+    wait: isInitialLoad ? 0 : 300,
+  });
 
   const handlePaste = useCallback((field: AnyFieldApi) => {
     pasteFromClipboard((pasted: string) => {

--- a/apps/web/src/hooks/queries/usePoolQueries.ts
+++ b/apps/web/src/hooks/queries/usePoolQueries.ts
@@ -2,6 +2,7 @@
 
 import { tanstackClient } from "@dex-web/orpc";
 import type {
+  GetPinedPoolOutput,
   GetPoolDetailsOutput,
   GetPoolReservesOutput,
 } from "@dex-web/orpc/schemas/index";
@@ -89,7 +90,7 @@ export function usePoolReservesSuspense(
  */
 export function usePinnedPools(options?: {
   enabled?: boolean;
-}): UseQueryResult<unknown> {
+}): UseQueryResult<GetPinedPoolOutput> {
   return useQuery({
     ...tanstackClient.pools.getPinedPool.queryOptions({
       context: { cache: "force-cache" as RequestCache },

--- a/libs/orpc/src/schemas/index.ts
+++ b/libs/orpc/src/schemas/index.ts
@@ -44,6 +44,7 @@ export type {
   CreatePoolTransactionInput,
   CreatePoolTransactionOutput,
 } from "./pools/createPoolTransaction.schema";
+export type { GetPinedPoolOutput } from "./pools/getPinedPool.schema";
 export type {
   GetPoolDetailsInput,
   GetPoolDetailsOutput,

--- a/libs/utils/src/common/unitConversion.ts
+++ b/libs/utils/src/common/unitConversion.ts
@@ -17,24 +17,20 @@ export const toRawUnitsBigNumber = (
 
 /**
  * Convert amount to raw units using BigNumber, returned as bigint (for server-side orpc handlers).
- * Validates that result is an integer and within u64 range.
+ * Rounds to the nearest integer and validates within u64 range.
  *
  * @param amount - Amount in human-readable units (number, string, or BigNumber)
  * @param decimals - Number of decimal places
  * @returns Raw units as bigint
- * @throws {Error} If result is not an integer or exceeds u64 maximum
+ * @throws {Error} If result exceeds u64 maximum
  */
 export const toRawUnitsBigNumberAsBigInt = (
   amount: number | string | BigNumber,
   decimals: number,
 ): bigint => {
-  const result = BigNumber(amount).multipliedBy(BigNumber(10 ** decimals));
-
-  if (!result.isInteger()) {
-    throw new Error(
-      `Amount ${amount} with ${decimals} decimals results in non-integer: ${result.toString()}`,
-    );
-  }
+  const result = BigNumber(amount)
+    .multipliedBy(BigNumber(10 ** decimals))
+    .integerValue(BigNumber.ROUND_DOWN);
 
   const MAX_U64 = BigNumber("18446744073709551615");
   if (result.isGreaterThan(MAX_U64)) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@solana/wallet-adapter-wallets": "^0.19.37",
     "@solana/web3.js": "^1.98.4",
     "@tanstack/react-form": "^1.23.5",
+    "@tanstack/react-pacer": "^0.16.4",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",
     "@xstate/react": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       "@tanstack/react-form":
         specifier: ^1.23.5
         version: 1.23.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      "@tanstack/react-pacer":
+        specifier: ^0.16.4
+        version: 0.16.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       "@tanstack/react-query":
         specifier: ^5.90.2
         version: 5.90.2(react@19.1.1)
@@ -7918,6 +7921,13 @@ packages:
         integrity: sha512-nI9Ad5JFHQjADkUQQtl7ajb7Lsd4sQlR0b5BmKDpJfZSPH/BF7+uUC3m91dM1bucOqIDzTTXr0QROZODnY+www==,
       }
 
+  "@tanstack/pacer@0.15.4":
+    resolution:
+      {
+        integrity: sha512-vGY+CWsFZeac3dELgB6UZ4c7OacwsLb8hvL2gLS6hTgy8Fl0Bm/aLokHaeDIP+q9F9HUZTnp360z9uv78eg8pg==,
+      }
+    engines: { node: ">=18" }
+
   "@tanstack/query-core@5.90.2":
     resolution:
       {
@@ -7947,6 +7957,16 @@ packages:
     peerDependenciesMeta:
       "@tanstack/react-start":
         optional: true
+
+  "@tanstack/react-pacer@0.16.4":
+    resolution:
+      {
+        integrity: sha512-nuQLE8bx0rYMiJau4jOTPZFp3XC/GnIHDKfKVVWeKUHNF4grRdVHPgTlJ8EV/nt/HJxSUnIcy+IIKX+Bj0bLSw==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      react: ">=16.8"
+      react-dom: ">=16.8"
 
   "@tanstack/react-query-devtools@5.90.2":
     resolution:
@@ -26975,6 +26995,11 @@ snapshots:
       "@tanstack/devtools-event-client": 0.3.2
       "@tanstack/store": 0.7.7
 
+  "@tanstack/pacer@0.15.4":
+    dependencies:
+      "@tanstack/devtools-event-client": 0.3.2
+      "@tanstack/store": 0.7.7
+
   "@tanstack/query-core@5.90.2": {}
 
   "@tanstack/query-devtools@5.90.1": {}
@@ -26992,6 +27017,13 @@ snapshots:
       react: 19.1.1
     transitivePeerDependencies:
       - react-dom
+
+  "@tanstack/react-pacer@0.16.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)":
+    dependencies:
+      "@tanstack/pacer": 0.15.4
+      "@tanstack/react-store": 0.7.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   "@tanstack/react-query-devtools@5.90.2(@tanstack/react-query@5.90.2(react@19.1.1))(react@19.1.1)":
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adopts @tanstack/react-pacer for debouncing, refactors queries to non-suspense hooks, removes heavy prefetching, and tightens types/utilities across swap/liquidity flows.
> 
> - **Frontend (Swap/Liquidity)**:
>   - **Debouncing**: Replace `use-debounce`/custom debounce with `@tanstack/react-pacer` (`useDebouncedValue`) in `SwapForm`, `SelectTokenModal`, and LP estimation hook; rework quote flow with `useCallback` + debounced params.
>   - **Query Hooks**: Introduce `usePoolDetails`/`usePinnedPools`; switch several `useSuspenseQuery` usages to `useQuery` with `enabled` flags; memoize address sorting with guards for empty tokens.
>   - **Prefetch Removal**: Strip server/route prefetch blocks for popular tokens/pools in select-token pages and remove hover prefetch from `SelectTokenButton`.
>   - **UI/UX**: Add `Suspense` wrapper for `CreatePoolForm` loader; tweak `TokenListInfinite` measurement/rerender.
>   - **Panels**: `FeaturesAndTrendingPoolPanel` now uses `usePinnedPools` and optional chaining; early return on no data.
>   - **YourLiquidity**: Use non-suspense token metadata query with `enabled`; simplify token metadata mapping.
> - **Utils/Types**:
>   - `toRawUnitsBigNumberAsBigInt`: round down to integer and keep u64-bound check (no non-integer throw).
>   - Export `GetPinedPoolOutput`; type `usePinnedPools` accordingly.
> - **Config**:
>   - Add dependency `@tanstack/react-pacer` and lock updates.
>   - Update Next types reference path in `apps/web/next-env.d.ts` and add doc comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 043c43f14cd140dc6dd34141f592c029a04032fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->