### PR TITLE
feat: show pool token stead of lp token in withdraw message

### DIFF
--- a/apps/web/src/app/[lang]/liquidity/_components/WithdrawLiquidityModal.tsx
+++ b/apps/web/src/app/[lang]/liquidity/_components/WithdrawLiquidityModal.tsx
@@ -183,6 +183,8 @@ export function WithdrawLiquidityModal({
     opts: {
       minTokenXOut: string;
       minTokenYOut: string;
+      tokenXOut: string;
+      tokenYOut: string;
       tokenXMint: string;
       tokenYMint: string;
       lpTokenAmount: string;
@@ -267,7 +269,7 @@ export function WithdrawLiquidityModal({
                 ? `Transaction initiated. You can now cast votes for this proposal on the Squads app.`
                 : isSubmitted
                   ? submittedToast.description
-                  : `Successfully withdrew ${opts.minTokenYOut} ${tokenYSymbol} + ${opts.minTokenXOut} ${tokenXSymbol}. Transaction: ${submitRes.signature}`}
+                  : `Successfully withdrew ${opts.tokenYOut} ${tokenYSymbol} + ${opts.tokenXOut} ${tokenXSymbol}. Transaction: ${submitRes.signature}`}
             </Text.Body2>
           </div>
         ),
@@ -396,7 +398,9 @@ export function WithdrawLiquidityModal({
           minTokenXOut: minXOut,
           minTokenYOut: minYOut,
           tokenXMint: gatewayTokenXAddress,
+          tokenXOut: expectedX.toString(),
           tokenYMint: gatewayTokenYAddress,
+          tokenYOut: expectedY.toString(),
         });
       } else {
         throw new Error(

--- a/apps/web/src/app/[lang]/liquidity/_components/WithdrawLiquidityModal.tsx
+++ b/apps/web/src/app/[lang]/liquidity/_components/WithdrawLiquidityModal.tsx
@@ -267,7 +267,7 @@ export function WithdrawLiquidityModal({
                 ? `Transaction initiated. You can now cast votes for this proposal on the Squads app.`
                 : isSubmitted
                   ? submittedToast.description
-                  : `Successfully withdrew ${form.state.values.withdrawalAmount}% of your liquidity. Transaction: ${submitRes.signature}`}
+                  : `Successfully withdrew ${opts.minTokenYOut} ${tokenYSymbol} + ${opts.minTokenXOut} ${tokenXSymbol}. Transaction: ${submitRes.signature}`}
             </Text.Body2>
           </div>
         ),


### PR DESCRIPTION
https://linear.app/darklake/issue/DAR-823/success-withdraw-toast-incorrect

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Success toast now displays actual withdrawn `tokenX/tokenY` amounts with symbols, threading values through the signing flow.
> 
> - **UI**:
>   - `apps/web/src/app/[lang]/liquidity/_components/WithdrawLiquidityModal.tsx`:
>     - Success toast now reports withdrawn amounts as ``${opts.tokenYOut} ${tokenYSymbol} + ${opts.tokenXOut} ${tokenXSymbol}`` instead of a percentage.
>     - Extend `requestSigning` options with `tokenXOut` and `tokenYOut`; compute from `expectedX/expectedY` and pass when invoking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40e9276686f991e18936f96456a461ca38b6c5bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->