### PR TITLE
fix: reorder reset calls in SwapForm to ensure proper state management

### DIFF
--- a/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
+++ b/apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx
@@ -214,12 +214,12 @@ export function SwapForm() {
         return;
       }
 
-      swapState.reset();
-      form.reset();
       const successMessage = isSquadsX(walletAdapter?.wallet)
         ? undefined
         : `SWAPPED ${form.state.values.tokenAAmount} ${tokenBAddress} FOR ${form.state.values.tokenBAmount} ${tokenAAddress}. protected from MEV attacks.`;
 
+      swapState.reset();
+      form.reset();
       toasts.dismiss();
 
       toasts.showSuccessToast(successMessage);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorders resets in SwapForm’s success handler to compute the success message before state/form are cleared.
> 
> - **Swap success flow** (`apps/web/src/app/[lang]/(swap)/_components/SwapForm.tsx`):
>   - Compute `successMessage` before calling `swapState.reset()` and `form.reset()` in `onSuccess`, ensuring message uses current form values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5ffffb2209ef1476b2a30823d00570ec1506e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->