### PR TITLE
feat: enhance liquidity form logic with token symbols and update transaction toasts

### DIFF
--- a/apps/web/src/app/[lang]/liquidity/_components/LiquidityForm.tsx
+++ b/apps/web/src/app/[lang]/liquidity/_components/LiquidityForm.tsx
@@ -41,6 +41,8 @@ export function LiquidityForm({ tokenPrices = {} }: LiquidityFormProps) {
     isPoolLoading,
     isSubmitting,
     send,
+    tokenASymbol,
+    tokenBSymbol,
   } = useLiquidityFormLogic({
     tokenAAddress,
     tokenBAddress,
@@ -170,15 +172,9 @@ export function LiquidityForm({ tokenPrices = {} }: LiquidityFormProps) {
                 estimatedLPTokens={lpEstimation.data?.estimatedLPTokens || ""}
                 form={form}
                 isLPEstimationLoading={lpEstimation.isLoading}
-                tokenASymbol={
-                  tokenAccountsData.tokenAAccount?.tokenAccounts?.[0]?.symbol ||
-                  ""
-                }
+                tokenASymbol={tokenASymbol}
                 tokenBAddress={tokenBAddress ?? ""}
-                tokenBSymbol={
-                  tokenAccountsData.tokenBAccount?.tokenAccounts?.[0]?.symbol ||
-                  ""
-                }
+                tokenBSymbol={tokenBSymbol}
                 tokenXMint={poolDetails?.tokenXMint}
                 tokenXReserve={poolDetails?.tokenXReserve}
                 tokenYReserve={poolDetails?.tokenYReserve}

--- a/apps/web/src/app/[lang]/liquidity/_hooks/useLiquidityFormLogic.ts
+++ b/apps/web/src/app/[lang]/liquidity/_hooks/useLiquidityFormLogic.ts
@@ -1,5 +1,6 @@
 "use client";
 import { useWallet } from "@solana/wallet-adapter-react";
+import { truncate } from "libs/utils/src/common/truncate";
 import { useRef } from "react";
 import { useRealtimePoolData } from "../../../../hooks/useRealtimePoolData";
 import {
@@ -28,6 +29,8 @@ export interface UseLiquidityFormLogicReturn {
   publicKey: ReturnType<typeof useWallet>["publicKey"];
   send: ReturnType<typeof useLiquidityTransaction>["send"];
   tokenAccountsData: UseRealtimeTokenAccountsReturn;
+  tokenASymbol: string;
+  tokenBSymbol: string;
 }
 
 export function useLiquidityFormLogic({
@@ -69,6 +72,13 @@ export function useLiquidityFormLogic({
     },
   });
 
+  const tokenASymbol =
+    tokenAccountsData.tokenAAccount?.tokenAccounts?.[0]?.symbol ||
+    truncate(tokenAAddress || "");
+  const tokenBSymbol =
+    tokenAccountsData.tokenBAccount?.tokenAccounts?.[0]?.symbol ||
+    truncate(tokenBAddress || "");
+
   const transaction = useLiquidityTransaction({
     onTransactionComplete: () => {
       markTransactionComplete();
@@ -77,7 +87,9 @@ export function useLiquidityFormLogic({
     poolDetails: poolDetails ?? null,
     resetForm: () => form.reset(),
     tokenAAddress,
+    tokenASymbol,
     tokenBAddress,
+    tokenBSymbol,
   });
 
   handleFormSubmitRef.current = transaction.handleFormSubmit;
@@ -93,5 +105,7 @@ export function useLiquidityFormLogic({
     publicKey,
     send: transaction.send,
     tokenAccountsData,
+    tokenASymbol,
+    tokenBSymbol,
   };
 }

--- a/apps/web/src/app/[lang]/liquidity/_hooks/useLiquidityTransaction.ts
+++ b/apps/web/src/app/[lang]/liquidity/_hooks/useLiquidityTransaction.ts
@@ -39,6 +39,8 @@ interface UseLiquidityTransactionParams {
   readonly resetForm?: () => void;
   readonly onTransactionComplete?: () => void;
   readonly orderContext: TokenOrderContext | null;
+  readonly tokenASymbol: string;
+  readonly tokenBSymbol: string;
 }
 
 export function useLiquidityTransaction({
@@ -48,6 +50,8 @@ export function useLiquidityTransaction({
   resetForm,
   onTransactionComplete,
   orderContext,
+  tokenASymbol,
+  tokenBSymbol,
 }: UseLiquidityTransactionParams) {
   const { signTransaction, wallet, publicKey } = useWallet();
   const { data: walletAdapter } = useWalletAdapter();
@@ -115,7 +119,22 @@ export function useLiquidityTransaction({
         throw new Error("Pool data is required");
       }
 
-      toasts.showStepToast(1);
+      toasts.showStepToast(1, [
+        {
+          key: "token-x-symbol",
+          value:
+            currentPoolData.tokenXMint === tokenAAddress
+              ? tokenASymbol
+              : tokenBSymbol,
+        },
+        {
+          key: "token-y-symbol",
+          value:
+            currentPoolData.tokenYMint === tokenBAddress
+              ? tokenBSymbol
+              : tokenASymbol,
+        },
+      ]);
 
       const tokenAAmount = parseAmount(values.tokenAAmount);
       const tokenBAmount = parseAmount(values.tokenBAmount);
@@ -232,6 +251,8 @@ export function useLiquidityTransaction({
       walletAdapter,
       tokenAAddress,
       tokenBAddress,
+      tokenASymbol,
+      tokenBSymbol,
       trackLiquidity,
       addLiquidityMutation,
       submitAddLiquidityMutation,

--- a/libs/core/src/constants/toastMessages.ts
+++ b/libs/core/src/constants/toastMessages.ts
@@ -1,6 +1,6 @@
 export const TRANSACTION_STEPS = {
   STEP_1: {
-    LIQUIDITY: "Depositing into pool",
+    LIQUIDITY: "Depositing into {token-x-symbol}/{token-y-symbol} pool",
     POOL_CREATION: "Preparing Pool Creation",
     SWAP: "Generating zero-knowledge proof",
   },

--- a/libs/core/src/hooks/useTransactionToasts.ts
+++ b/libs/core/src/hooks/useTransactionToasts.ts
@@ -35,7 +35,10 @@ export interface UseTransactionToastsParams {
 }
 
 export interface UseTransactionToastsReturn {
-  showStepToast: (step: number) => void;
+  showStepToast: (
+    step: number,
+    params?: { key: string; value: string }[],
+  ) => void;
   showSuccessToast: (message?: string, customAction?: React.ReactNode) => void;
   showErrorToast: (
     error: string | Error,
@@ -87,15 +90,23 @@ export const useTransactionToasts = ({
   customMessages,
 }: UseTransactionToastsParams): UseTransactionToastsReturn => {
   const showStepToast = useCallback(
-    (step: number) => {
+    (step: number, params?: { key: string; value: string }[]) => {
       const stepKey = `STEP_${step}` as keyof typeof TRANSACTION_STEPS;
       const stepData = TRANSACTION_STEPS[stepKey];
       const descriptionData = TRANSACTION_DESCRIPTIONS[stepKey];
 
       if (stepData && descriptionData) {
+        let title: string = stepData[transactionType];
+
+        if (params && params.length > 0) {
+          params.forEach(({ key, value }) => {
+            title = title.replace(`{${key}}`, value);
+          });
+        }
+
         toast({
           description: descriptionData[transactionType],
-          title: stepData[transactionType],
+          title,
           variant: "loading",
         });
       }


### PR DESCRIPTION

<img width="371" height="190" alt="Screenshot 2025-10-14 at 13 59 43" src="https://github.com/user-attachments/assets/a8f4802b-28b1-41dc-b2e5-4422dcb63f57" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Derives token symbols (with address fallback) and injects them into the step-1 liquidity toast title, wiring symbols through form and transaction hooks.
> 
> - **Liquidity flow**:
>   - **Form logic (`useLiquidityFormLogic`)**: Derives `tokenASymbol`/`tokenBSymbol` (fallback to truncated address) and returns them; passes to `useLiquidityTransaction`.
>   - **Form UI (`LiquidityForm.tsx`)**: Uses `tokenASymbol`/`tokenBSymbol` from logic for `AddLiquidityDetails` props (no longer reads directly from `tokenAccountsData`).
>   - **Transaction hook (`useLiquidityTransaction`)**: Accepts symbols and calls `toasts.showStepToast(1, [...])` with `{token-x-symbol}`/`{token-y-symbol}` values based on `tokenXMint`/`tokenYMint`.
> - **Core toasts**:
>   - **Messages (`toastMessages.ts`)**: Update `TRANSACTION_STEPS.STEP_1.LIQUIDITY` to "Depositing into {token-x-symbol}/{token-y-symbol} pool".
>   - **API (`useTransactionToasts`)**: `showStepToast(step, params?)` now supports placeholder substitution via provided `params`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8adc31fa537387f2089852d5a09ba935d687bf0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->