### PR TITLE
feat: improve FormFieldset loading state

### DIFF
--- a/apps/web/src/app/_components/FormFieldset.tsx
+++ b/apps/web/src/app/_components/FormFieldset.tsx
@@ -158,20 +158,15 @@ export function FormFieldset({
               {(isLoading && !tokenAccount) || !tokenAccount ? (
                 <SkeletonLoader className="w-28" variant="balance" />
               ) : (
-                <>
-                  <span>
-                    {numberFormatHelper({
-                      decimalScale: 2,
-                      thousandSeparator: true,
-                      trimTrailingZeros: true,
-                      value: convertToDecimal(amount, decimals).toString(),
-                    })}{" "}
-                    {tokenSymbol}
-                  </span>
-                  {isRefreshing && (
-                    <div className="ml-2 h-3 w-3 animate-spin rounded-full border border-green-300 border-t-transparent opacity-70"></div>
-                  )}
-                </>
+                <span>
+                  {numberFormatHelper({
+                    decimalScale: 2,
+                    thousandSeparator: true,
+                    trimTrailingZeros: true,
+                    value: convertToDecimal(amount, decimals).toString(),
+                  })}{" "}
+                  {tokenSymbol}
+                </span>
               )}
             </span>
             {tokenAccount && (

--- a/apps/web/src/app/_components/__tests__/FormFieldset.loading-state.spec.tsx
+++ b/apps/web/src/app/_components/__tests__/FormFieldset.loading-state.spec.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { describe, expect, it, vi } from "vitest";
+import { FormFieldset } from "../FormFieldset";
+
+vi.mock("../../../_utils/useFormatPrice", () => ({
+  useFormatPrice: vi.fn(() => "$0.00"),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  const onUrlUpdate = vi.fn();
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <NextIntlClientProvider locale="en" messages={{}}>
+      <NuqsTestingAdapter
+        onUrlUpdate={onUrlUpdate}
+        searchParams={{ tokenAAddress: "token-a", tokenBAddress: "token-b" }}
+      >
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </NuqsTestingAdapter>
+    </NextIntlClientProvider>
+  );
+
+  return { Wrapper };
+};
+
+describe("FormFieldset loading visuals", () => {
+  it("does not render inline spinner when refreshing token balances", () => {
+    const { Wrapper } = createWrapper();
+
+    const { container } = render(
+      <FormFieldset
+        isLoading={false}
+        isRefreshing
+        name="tokenAmount"
+        onBlur={vi.fn()}
+        onChange={vi.fn()}
+        onClearPendingCalculations={vi.fn()}
+        onHalfMaxClick={vi.fn()}
+        tokenAccount={{
+          address: "test-account",
+          amount: 1_000_000,
+          decimals: 6,
+          symbol: "USDC",
+        }}
+        value=""
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    const balanceRow = screen.getByText(/USDC/);
+    expect(balanceRow).toHaveTextContent(/1\s+USDC/i);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the inline spinner when refreshing token balances in `FormFieldset` and adds a test verifying static balance display.
> 
> - **UI**:
>   - Remove inline refreshing spinner from balance display in `apps/web/src/app/_components/FormFieldset.tsx`; show static formatted balance only.
> - **Tests**:
>   - Add `apps/web/src/app/_components/__tests__/FormFieldset.loading-state.spec.tsx` to ensure no spinner renders during refresh and the balance is displayed (e.g., `1 USDC`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b2c9419a9754cde87d580224154cdc357600f86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->