### PR TITLE
feat: update Hero component and page styles for improved layout

### DIFF
--- a/apps/web/src/app/[lang]/(swap)/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/page.tsx
@@ -94,14 +94,15 @@ export default async function Page({
         <div className="flex w-full max-w-xl flex-col items-center justify-center">
           <section className="hidden w-full items-start gap-1 md:flex">
             <div className="size-9" />
-            <Box className="mb-0 bg-green-800 pb-0">
+            <Box className="mb-0 bg-green-800 p-0">
               <Hero
                 className="gap-4"
                 image="/images/waddles/pose4.png"
                 imageClassName="scale-x-[-1] "
+                imageHeight={195}
                 imagePosition="end"
               >
-                <div className="flex flex-col gap-3 uppercase">
+                <div className="flex flex-col gap-3 py-4 pl-6 uppercase">
                   <Text.Heading>swap</Text.Heading>
                   <div className="flex flex-col text-md">
                     <Text.Body2 className="text-md md:text-lg">

--- a/apps/web/src/app/[lang]/(swap)/page.tsx
+++ b/apps/web/src/app/[lang]/(swap)/page.tsx
@@ -98,9 +98,10 @@ export default async function Page({
               <Hero
                 className="gap-4"
                 image="/images/waddles/pose4.png"
-                imageClassName="scale-x-[-1] "
+                imageClassName="scale-x-[-1] right-4"
                 imageHeight={195}
                 imagePosition="end"
+                imageWidth={200}
               >
                 <div className="flex flex-col gap-3 py-4 pl-6 uppercase">
                   <Text.Heading>swap</Text.Heading>

--- a/apps/web/src/app/[lang]/liquidity/page.tsx
+++ b/apps/web/src/app/[lang]/liquidity/page.tsx
@@ -170,14 +170,15 @@ export default async function Page({
         <div className="flex w-full max-w-xl flex-col items-center justify-center">
           <section className="hidden w-full items-start gap-1 md:flex">
             <div className="size-9" />
-            <Box className="mb-0 bg-green-800 pb-0">
+            <Box className="mb-0 bg-green-800 p-0">
               <Hero
                 className="gap-4"
                 image="/images/waddles/pose4.png"
                 imageClassName="scale-x-[-1]"
+                imageHeight={195}
                 imagePosition="end"
               >
-                <div className="flex flex-col gap-3 uppercase">
+                <div className="flex flex-col gap-3 py-4 pl-6 uppercase">
                   <Text.Heading>liquidity</Text.Heading>
                   <div className="flex flex-col text-md">
                     <Text.Body2 className="text-md md:text-lg">

--- a/apps/web/src/app/[lang]/liquidity/page.tsx
+++ b/apps/web/src/app/[lang]/liquidity/page.tsx
@@ -173,10 +173,11 @@ export default async function Page({
             <Box className="mb-0 bg-green-800 p-0">
               <Hero
                 className="gap-4"
-                image="/images/waddles/pose4.png"
-                imageClassName="scale-x-[-1]"
-                imageHeight={195}
+                image="/images/waddles/pose3.png"
+                imageClassName="right-6"
+                imageHeight={198}
                 imagePosition="end"
+                imageWidth={180}
               >
                 <div className="flex flex-col gap-3 py-4 pl-6 uppercase">
                   <Text.Heading>liquidity</Text.Heading>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default async function RootLayout({
                     </Text.Body2>
                   </div>
                 </Box>
-                <div className="hidden md:block">{children}</div>
+                <div className="mt-20 hidden md:block">{children}</div>
               </PageLayout>
               {modal}
             </ReferralCodeProvider>

--- a/libs/ui/src/lib/Hero/Hero.tsx
+++ b/libs/ui/src/lib/Hero/Hero.tsx
@@ -21,13 +21,16 @@ export function Hero({
 }: HeroProps) {
   return (
     <div
-      className={twMerge("flex items-center justify-between", className)}
+      className={twMerge(
+        "relative flex items-center justify-between",
+        className,
+      )}
       {...props}
     >
       {imagePosition === "start" && (
         <Image
           alt="Waddles"
-          className={twMerge("self-start", imageClassName)}
+          className={twMerge("left-0 self-start", imageClassName)}
           height={imageHeight ?? 420}
           src={image}
           style={{ height: "auto", width: "auto" }}
@@ -38,7 +41,7 @@ export function Hero({
       {imagePosition === "end" && (
         <Image
           alt="Waddles"
-          className={twMerge("self-end", imageClassName)}
+          className={twMerge("right-0 self-end", imageClassName)}
           height={imageHeight ?? 420}
           src={image}
           style={{ height: "auto", width: "auto" }}

--- a/libs/ui/src/lib/Hero/Hero.tsx
+++ b/libs/ui/src/lib/Hero/Hero.tsx
@@ -33,7 +33,6 @@ export function Hero({
           className={twMerge("absolute left-0 self-start", imageClassName)}
           height={imageHeight ?? 420}
           src={image}
-          style={{ height: "auto", width: "auto" }}
           width={imageWidth ?? 200}
         />
       )}
@@ -44,7 +43,6 @@ export function Hero({
           className={twMerge("absolute right-0 self-end", imageClassName)}
           height={imageHeight ?? 420}
           src={image}
-          style={{ height: "auto", width: "auto" }}
           width={imageWidth ?? 200}
         />
       )}

--- a/libs/ui/src/lib/Hero/Hero.tsx
+++ b/libs/ui/src/lib/Hero/Hero.tsx
@@ -30,7 +30,7 @@ export function Hero({
       {imagePosition === "start" && (
         <Image
           alt="Waddles"
-          className={twMerge("left-0 self-start", imageClassName)}
+          className={twMerge("absolute left-0 self-start", imageClassName)}
           height={imageHeight ?? 420}
           src={image}
           style={{ height: "auto", width: "auto" }}
@@ -41,7 +41,7 @@ export function Hero({
       {imagePosition === "end" && (
         <Image
           alt="Waddles"
-          className={twMerge("right-0 self-end", imageClassName)}
+          className={twMerge("absolute right-0 self-end", imageClassName)}
           height={imageHeight ?? 420}
           src={image}
           style={{ height: "auto", width: "auto" }}


### PR DESCRIPTION
<img width="587" height="234" alt="image" src="https://github.com/user-attachments/assets/b7a2e74a-9907-4d66-ba26-36c75759c778" />

also for ticket: https://linear.app/darklake/issue/DAR-670/waddles-slightly-incorrect-styling

<img width="571" height="232" alt="image" src="https://github.com/user-attachments/assets/826bdf34-fbd3-4a4f-85f8-0211ccd46044" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Absolute-position the Waddles image in `Hero` and adjust swap/liquidity page hero images and spacing, plus minor layout padding tweaks.
> 
> - **UI Library**:
>   - **`libs/ui/src/lib/Hero/Hero.tsx`**:
>     - Wrap container with `relative`; move hero `Image` to absolute `left-0`/`right-0` depending on `imagePosition`.
>     - Update default classes (`self-start`/`self-end` -> absolute) and remove inline size styles.
> - **Web App Pages**:
>   - **Swap (`apps/web/src/app/[lang]/(swap)/page.tsx`)**:
>     - `Box` padding: `pb-0` -> `p-0`.
>     - `Hero` tweaks: add `right-4`, set `imageHeight={195}`, `imageWidth={200}`, and add `py-4 pl-6` to content.
>   - **Liquidity (`apps/web/src/app/[lang]/liquidity/page.tsx`)**:
>     - `Box` padding: `pb-0` -> `p-0`.
>     - `Hero` image updated to `/images/waddles/pose3.png`, add `right-6`, set `imageHeight={198}`, `imageWidth={180}`, and add `py-4 pl-6` to content.
>   - **Layout (`apps/web/src/app/layout.tsx`)**:
>     - Add `mt-20` margin to desktop children container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f39458052b949e0f06cbfc354f373110d941919b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->